### PR TITLE
Fix auth missing from session after first login

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,7 @@
 const { User } = require("./db/models");
 
 const restoreUser = async (req, res, next) => {
+  console.log(req.session);
   if (!req.session.auth || !req.session.auth.userId) {
     res.locals.authenticated = false;
     return next();
@@ -29,7 +30,15 @@ const restoreUser = async (req, res, next) => {
  * @param {*} user
  */
 const loginUser = (req, user) => {
-  req.session.auth = { userId: user.id };
+  return new Promise((resolve, reject) => {
+    req.session.auth = { userId: user.id };
+    req.session.save((err) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve();
+    })
+  })
 };
 
 const redirectUnauthedToLogin = async (req, res, next) => {

--- a/auth.js
+++ b/auth.js
@@ -1,7 +1,6 @@
 const { User } = require("./db/models");
 
 const restoreUser = async (req, res, next) => {
-  console.log(req.session);
   if (!req.session.auth || !req.session.auth.userId) {
     res.locals.authenticated = false;
     return next();

--- a/routes/users.js
+++ b/routes/users.js
@@ -111,7 +111,7 @@ router.post(
     const matches = await bcrypt.compare(password, user.password.toString());
 
     if (matches) {
-      loginUser(req, user);
+      await loginUser(req, user);
       res.redirect("/");
       return;
     }
@@ -134,7 +134,7 @@ router.get(
       return failedLogin(req, res);
     }
 
-    loginUser(req, user);
+    await loginUser(req, user);
     res.redirect("/");
   })
 );
@@ -175,7 +175,7 @@ router.post(
         username,
         password: hashedPass,
       });
-      loginUser(req, user);
+      await loginUser(req, user);
       res.redirect("/");
     } catch (error) {
       next(error);


### PR DESCRIPTION
Seems like there was a race condition happening here. We can use `.save` on session to ensure that the information is saved into the database before continuing to redirect to the home page.

Fixes #26 