### PR TITLE
Fix broken image urls in nested routes

### DIFF
--- a/views/create-story.pug
+++ b/views/create-story.pug
@@ -10,7 +10,7 @@ append head
 
 block navbar
   a(href="/" alt="CodeX Home")
-    img.logo(src="../images/codexLogo.png" alt="CodeX Logo" )
+    img.logo(src="/images/codexLogo.png" alt="CodeX Logo" )
   nav
     form(method='post' action='/stories/new')
       input(type="hidden" name="_csrf" value=csrfToken)

--- a/views/index.pug
+++ b/views/index.pug
@@ -16,7 +16,7 @@ block content
         p.cta-body.sans-serif It's easy and free to post your thinking on any topic and connect with millions of readers.
         form(action='/login' method='get')
           button.button.contained.rounded.startWriting Start Writing
-      img(src="../images/codexLogo.png" class='biglogo' alt="logo")
+      img(src="/images/codexLogo.png" class='biglogo' alt="logo")
   .trending.mid-content-enclose
     .mid-content.wide-container.sans-serif
       p.mid-content-title Trending on Codex!

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -19,14 +19,14 @@ html
         block navbar
           if locals.authenticated
             a(href="/" alt="CodeX Home")
-              img.logo(src="../images/codexLogo.png" alt="CodeX Logo" )
+              img.logo(src="/images/codexLogo.png" alt="CodeX Logo" )
             nav
               form(method="get" action="/stories/new")
                 button.button.contained.rounded.black Write a Story
               include includes/nav-user-dropdown.pug
           else
             a(href="/" alt="CodeX Home")
-              img.logo(src="../images/codexLogo.png" alt="CodeX Logo")
+              img.logo(src="/images/codexLogo.png" alt="CodeX Logo")
             nav
               a(href="") Our story
               a(href="/login") Write


### PR DESCRIPTION
Images could appear broken if the path went too deep. The urls contained a `../` instead of having them start at root `/`.