### PR TITLE
Redirect to signup if comment input is clicked when not authed

### DIFF
--- a/public/stylesheets/global.css
+++ b/public/stylesheets/global.css
@@ -140,7 +140,7 @@ h6,
 .button.contained.black:hover {
   background-color: #080808;
   border-color: #292929;
-  color:rgba(255, 255, 255, 0.90);
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .button.icon-button {
@@ -158,7 +158,7 @@ h6,
   width: 20px;
 }
 .profpic:hover {
-  cursor:pointer;
+  cursor: pointer;
 }
 
 /*
@@ -260,4 +260,8 @@ h6,
 
 .display-after-loaded {
   display: none;
+}
+
+.pointer {
+  cursor: pointer;
 }

--- a/views/story.pug
+++ b/views/story.pug
@@ -63,13 +63,11 @@ block content
           h2 Responses (#{comments.length})
           div
             i.fa-solid.fa-xmark.modal-close
-        form.comments-input-wrapper(action=`/stories/${story.id}/comment` method="POST" id='commForm')
-          input(type="hidden" name="_csrf" value=csrfToken)
-          textarea#story-comment-input.comments-input(name='commentBox' placeholder="What are your thoughts?")
-          div.comment-input-actions
-            div
-              button.button.text.comment-cancel Cancel
-              button.button.contained.rounded.comment-respond(form='commForm') Respond
+        if locals.authenticated
+          +commentForm(csrfToken, story)
+        else
+          a(href="/signup")
+            +commentForm(csrfToken, story)
         .divider
         .comments-container
           each comment in comments
@@ -90,3 +88,12 @@ block content
                   a.like-comment(data-like-id=userCommentLike.id data-liked=!!userCommentLike.id)
                     i.fa-solid.fa-hands-clapping
                   a #{comment.CommentLikes.length}
+
+mixin commentForm(csrfToken, story)
+  form.comments-input-wrapper(action=`/stories/${story.id}/comment` method="POST" id='commForm')
+    input(type="hidden" name="_csrf" value=csrfToken)
+    textarea#story-comment-input.comments-input(name='commentBox' placeholder="What are your thoughts?" class=`${locals.authenticated ? "" : "pointer"}`)
+    div.comment-input-actions
+      div
+        button.button.text.comment-cancel Cancel
+        button.button.contained.rounded.comment-respond(form='commForm') Respond


### PR DESCRIPTION
Since an unauthed user cannot leave a comment, direct the user to a signup page when they try to click into the input box.