### PR TITLE
Fix story body images extending past container

### DIFF
--- a/public/stylesheets/story.css
+++ b/public/stylesheets/story.css
@@ -97,6 +97,10 @@ main h2 {
   margin-bottom: -0.46em;
 }
 
+#story-body img {
+  width: 100%;
+}
+
 #story-body p,
 #story-body ol,
 #story-body ul {


### PR DESCRIPTION
Images that were included in the story body extended past its container. This resolves that issue by setting a width to the image of 100%, which will limit it to the width of the parent.