### PR TITLE
Hide story edit button when not author

### DIFF
--- a/views/story.pug
+++ b/views/story.pug
@@ -46,8 +46,9 @@ block content
                 i.fa-solid.fa-comment
                 span #{comments.length}
           div.right
-            a.button.icon-button.rounded(href=`/stories/${story.id}/edit`)
-              i.fa-solid.fa-pen-to-square
+            if story.user.id === locals.user.id
+              a.button.icon-button.rounded(href=`/stories/${story.id}/edit`)
+                i.fa-solid.fa-pen-to-square
     footer
       .wide-container
         .content-wrapper

--- a/views/story.pug
+++ b/views/story.pug
@@ -46,7 +46,7 @@ block content
                 i.fa-solid.fa-comment
                 span #{comments.length}
           div.right
-            if story.user.id === locals.user.id
+            if locals.user && story.user.id === locals.user.id
               a.button.icon-button.rounded(href=`/stories/${story.id}/edit`)
                 i.fa-solid.fa-pen-to-square
     footer


### PR DESCRIPTION
Currently, the edit button at the bottom of the story was visible to anyone. This prevents the button from being added to the page unless there is a logged-in user and they are the author.