### PR TITLE
Hide image in story grid if there is no header image

### DIFF
--- a/public/stylesheets/auth-index.css
+++ b/public/stylesheets/auth-index.css
@@ -21,7 +21,3 @@
     margin-bottom: 48px;
   }
 }
-
-.inner-story {
-  margin-right: 20px;
-}

--- a/public/stylesheets/index.css
+++ b/public/stylesheets/index.css
@@ -227,8 +227,8 @@ nav .login.button {
   margin-left:20px;
 }
 
-.end-content .inner-story {
-  margin-right: 20px;
+.story-grid-story > a {
+  margin-left: 20px;
 }
 
 .headings-wrapper h2,

--- a/views/mixins/story-grid-items.pug
+++ b/views/mixins/story-grid-items.pug
@@ -23,5 +23,6 @@ mixin detailedStoryGridItem(post)
           h2=post.heading
           h3=post.subText
         p.meta-data.sans-serif=post.createdAt.toLocaleDateString("en-US", { month: "short", day: "numeric" })
-    a(href=`/stories/${post.id}`)
-      img(src=post.headerImage class='listimg' alt=post.heading)
+    if post.headerImage
+      a(href=`/stories/${post.id}`)
+        img(src=post.headerImage class='listimg' alt=post.heading)


### PR DESCRIPTION
This adds proper handling for cases where a header image was not defined for the story. Stories without a header image should not attempt to render an image in the list and should be formatted to take the full width of the list.

Fixes #49 