### PR TITLE
Incorrect autoresized textarea size with ending line break

### DIFF
--- a/public/javascripts/input-utils.js
+++ b/public/javascripts/input-utils.js
@@ -4,7 +4,13 @@
  * @param {HTMLElement} textarea the text area element
  */
 export const updateTextAreaHeight = (growHidden, textarea) => {
-  growHidden.innerText = textarea.value;
+  const endsWithNewLine = /\n$/g.test(textarea.value);
+
+  if (endsWithNewLine) {
+    growHidden.innerText = textarea.value + "\n";
+  } else {
+    growHidden.innerText = textarea.value;
+  }
 };
 
 /**


### PR DESCRIPTION
When you started a new line in an auto resized text area, the height did not update to account for the line break as expected in a textarea.

To account for this, I check if the value ends with a line break and insert an additional one. Once any other character is entered, that second line break is removed.

Prevously:
![hxZAPs95s3](https://user-images.githubusercontent.com/25138621/142809576-8eb11ca6-eaac-418a-8d79-d21e515dd47e.gif)

Updated:
![XEsOFNOzjW](https://user-images.githubusercontent.com/25138621/142809604-461b261a-e724-4620-b51d-c875dd3d4eaf.gif)

