### PR TITLE
Prevent story sidebar showing initially

### DIFF
--- a/views/story.pug
+++ b/views/story.pug
@@ -60,7 +60,7 @@ block content
           nav
             a.inherit-color.sans-serif(href="/about") About
             a.inherit-color.sans-serif(href="/stories/new") Write
-  .post-sidebar
+  .post-sidebar.hidden
     .container-wrapper
       .wide-container
         .post-sidebar-content-wrapper.sans-serif


### PR DESCRIPTION
The sidebar on the story page initially is set to be visible. This results in momentary visibility of the sidebar before it is hidden from the observer.