### PR TITLE
Story Sidebar appeared before intended

### DIFF
--- a/public/javascripts/story.js
+++ b/public/javascripts/story.js
@@ -332,7 +332,7 @@ function setupSidebarObserver() {
     entries.forEach((entry) => {
       if (entry.isIntersecting) {
         postSidebar.classList.add("hidden");
-      } else {
+      } else if (storyHeader.getBoundingClientRect().top < 0) {
         postSidebar.classList.remove("hidden");
       }
     });

--- a/public/stylesheets/story.css
+++ b/public/stylesheets/story.css
@@ -344,6 +344,7 @@ footer nav > a:last-of-type {
 
 .post-sidebar.hidden {
   opacity: 0;
+  pointer-events: none;
 }
 
 .post-sidebar-content-wrapper {


### PR DESCRIPTION
The story sidebar was showing before the title had been scrolled past. This was caused only at smaller screens with large images that would cause the title to be below the initial viewport size.

This ensures that the title is "above" the viewport before removing the hidden class from the sidebar.

I've also resolved an issue that allowed buttons in the sidebar to be clicked even while it was hidden.

Closes #65 