### PR TITLE
Make sidebar follow button visibility consistent

### DIFF
--- a/views/story.pug
+++ b/views/story.pug
@@ -67,8 +67,9 @@ block content
           .sidebar-author
             .story-author=story.user.username
             .author-actions
-              button.button.contained.rounded.follow-button(data-author-id=story.user.id data-follow-id=userFollow.id)
-                | #{userFollow.id ? "Unfollow" : "Follow"}
+              if !locals.authenticated || story.user.id !== locals.user.id
+                button.button.contained.rounded.follow-button(data-author-id=story.user.id data-follow-id=userFollow.id)
+                  | #{userFollow.id ? "Unfollow" : "Follow"}
           .post-actions
             div.likes
               a.like-post(data-like-id=userLike.id data-liked=!!userLike.id data-story-id=story.id)


### PR DESCRIPTION
The follow button on the sidebar did not follow the same conditional logic to display like the one in the navbar. This fixes that and makes them consistent.